### PR TITLE
Lazily add left and right container.

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/DrawerMenu.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/DrawerMenu.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1200"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DrawerMenu"
+               BuildableName = "DrawerMenu"
+               BlueprintName = "DrawerMenu"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DrawerMenuTests"
+               BuildableName = "DrawerMenuTests"
+               BlueprintName = "DrawerMenuTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DrawerMenuTests"
+               BuildableName = "DrawerMenuTests"
+               BlueprintName = "DrawerMenuTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DrawerMenu"
+            BuildableName = "DrawerMenu"
+            BlueprintName = "DrawerMenu"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
         "package": "DrawerMenu",
         "repositoryURL": "git@github.com:brandenesmith/DrawerMenu.git",
         "state": {
-          "branch": "feature/AddSPMSupport",
-          "revision": "40cc5b7c2800964e6e95650d974da64c5d7ce1d7",
+          "branch": "master",
+          "revision": "1bf7e471177768ce9f7c1e3dbb376aa5fac360ed",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "DrawerMenu",
+    platforms: [
+        .iOS(.v13)
+    ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/DrawerMenu/DrawerMenu.swift
+++ b/Sources/DrawerMenu/DrawerMenu.swift
@@ -140,6 +140,12 @@ public class DrawerMenu: UIViewController, UIGestureRecognizerDelegate {
 
     public func open(to side: Side, animated: Bool = true, completion: (() -> Void)? = nil) {
         if side == .left {
+            guard let leftContainer = leftContainerView else { return }
+
+            if !self.view.subviews.contains(leftContainer) {
+                self.view.addSubview(leftContainer)
+            }
+
             updateLeftProgress(status: .open, animated: animated) { [weak self] in
                 completion?()
                 self?.isOpenLeft = true
@@ -147,6 +153,12 @@ public class DrawerMenu: UIViewController, UIGestureRecognizerDelegate {
             }
         }
         if side == .right {
+            guard let rightContainer = rightContainerView else { return }
+
+            if !self.view.subviews.contains(rightContainer) {
+                self.view.addSubview(rightContainer)
+            }
+
             updateRightProgress(status: .open, animated: animated) { [weak self] in
                 completion?()
                 self?.isOpenRight = true
@@ -196,9 +208,13 @@ public class DrawerMenu: UIViewController, UIGestureRecognizerDelegate {
             leftContainerView = UIView()
             leftContainerView?.frame = frame
             leftContainerView?.autoresizingMask = [.flexibleHeight, .flexibleWidth]
-            view.addSubview(leftContainerView!)
 
             addChild(left)
+
+            // Note that we are adding the left view to the leftContainerView here, but
+            // we will lazily add the left container view to avoid life cycle methods
+            // such as viewDidAppear: from being called before the view has actually
+            // appeared.
             leftContainerView?.addSubview(left.view)
             left.didMove(toParent: self)
 
@@ -216,9 +232,14 @@ public class DrawerMenu: UIViewController, UIGestureRecognizerDelegate {
             rightContainerView = UIView()
             rightContainerView?.frame = frame
             rightContainerView?.autoresizingMask = [.flexibleHeight, .flexibleWidth]
-            view.addSubview(rightContainerView!)
+
 
             addChild(right)
+
+            // Note that we are adding the right view to the rightContainerView here, but
+            // we will lazily add the right container view to avoid life cycle methods
+            // such as viewDidAppear: from being called before the view has actually
+            // appeared.
             rightContainerView?.addSubview(right.view)
             right.didMove(toParent: self)
 

--- a/Tests/DrawerMenuTests/DrawerMenuTests.swift
+++ b/Tests/DrawerMenuTests/DrawerMenuTests.swift
@@ -6,7 +6,6 @@ final class DrawerMenuTests: XCTestCase {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct
         // results.
-        XCTAssertEqual(DrawerMenu().text, "Hello, World!")
     }
 
     static var allTests = [


### PR DESCRIPTION
# Summary

This change lazily adds the left and right container views so that life cycle method `viewDidApear(_:)` isn't
called before the view actually appears.